### PR TITLE
refactor: Implement participant lazy loading & fix standalone components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "ng build --configuration=production",
     "watch": "ng build --watch --configuration=development",
     "http-server": "http-server dist/frontend-projek-sertifikat-berbasis-web/browser -s index.html -a 0.0.0.0 -p 4200",
-    "test": "ng test"
+    "test": "ng test",
+    "start:once": "ng serve --host 0.0.0.0 --watch=false"
   },
   "private": true,
   "dependencies": {

--- a/src/app/features/participant/participant.module.ts
+++ b/src/app/features/participant/participant.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { ParticipantRoutingModule } from './participant-routing.module';
+
+import { ParticipantListComponent } from './participant-list/participant-list.component';
+import { AddParticipantDataComponent } from './add-participant-data/add-participant-data.component';
+import { ParticipantDetailComponent } from './participant-detail/participant-detail.component';
+import { EditParticipantDataComponent } from './edit-participant-data/edit-participant-data.component';
+import { IdCardComponent } from './id-card/id-card.component';
+import { DisplaysParticipantFilesComponent } from './displays-participants-files/displays-participant-file.component';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    ParticipantRoutingModule,
+    ParticipantListComponent,
+    AddParticipantDataComponent,
+    ParticipantDetailComponent,
+    EditParticipantDataComponent,
+    IdCardComponent,
+    DisplaysParticipantFilesComponent
+  ]
+})
+export class ParticipantModule { }


### PR DESCRIPTION
### Summary
- Implementasi lazy loading untuk modul Participant
- Perbaikan standalone components di `participant.module.ts`
- Penambahan skrip `start:once` di `package.json`
- Pembaruan dokumentasi: `task-frontend.mdc`, `planning-frontend.mdc`, `project-structure.mdc`, [global-rules.md](cci:7://file:///home/bakung/Documents/cache/gmf/.windsurf/rules/global-rules.md:0:0-0:0)

### Testing
- Build sukses dengan `pnpm run build`
- Chunk terpisah dibuat: `chunk-ZXXA6PPU.js | participant-module | 48.06 kB`